### PR TITLE
Update plug with unique ID based on MAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ Python library interface to EcoPlug wifi outlet.
 
 Until proper documentation...
 
+Allow UDP 8900 inbound in firewall
+
     >>> from pyecoplug import *
     >>> plugs = {}
     >>> def add(s):

--- a/pyecoplug/plug.py
+++ b/pyecoplug/plug.py
@@ -9,7 +9,10 @@ class EcoPlug(object):
 
     def __init__(self, data):
         self.plug_data = data
+        # Name set for outlet in phone app
         self.name = data[3].decode('utf-8')
+        # 'Manufacturer-partial MAC' as unique ID (e.g. 'ECO-123456')
+        self.ident = data[2].decode('utf-8')
 
         self._pending = {}
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='pyecoplug',
-        version='0.0.5',
+        version='0.0.6',
         description='Interface for the EcoPlug outlet',
         url='http://github.com/philburr/pyecoplug',
         author='phil.burr@gmail.com',


### PR DESCRIPTION
This PR updates pyecoplug to expose a unique identifier for each ecoplug unit such that the entity can have a unique ID in Home Assistant.  This allows some additional feature with the entity in HASS.